### PR TITLE
refactor: preview width constraint

### DIFF
--- a/js/frontify_media_form.js
+++ b/js/frontify_media_form.js
@@ -68,7 +68,7 @@
               assets[0].previewUrl;
             $fieldItem
               .querySelector('img.frontify-image-preview')
-              .setAttribute('src', assets[0].previewUrl);
+              .setAttribute('src', assets[0].previewUrl + '?width=' + drupalSettings.Frontify.preview_image_width);
             $fieldItem.querySelector('input.frontify-asset-id').value =
               assets[0].id;
             $fieldItem.querySelector('input.frontify-asset-name').value =

--- a/src/Plugin/Field/FieldWidget/FrontifyAssetFieldWidget.php
+++ b/src/Plugin/Field/FieldWidget/FrontifyAssetFieldWidget.php
@@ -21,6 +21,8 @@ use Drupal\link\Plugin\Field\FieldWidget\LinkWidget;
 )]
 class FrontifyAssetFieldWidget extends LinkWidget {
 
+  protected const int PREVIEW_IMAGE_WIDTH = 400;
+
   /**
    * Form element validation handler for the 'uri' element.
    *
@@ -63,7 +65,7 @@ class FrontifyAssetFieldWidget extends LinkWidget {
 
     $element['frontify_preview'] = [
       '#theme' => 'image',
-      '#uri' => $item->uri,
+      '#uri' => $item->uri . '?width=' . self::PREVIEW_IMAGE_WIDTH,
       '#alt' => $item->name,
       '#title' => $item->name,
       '#attributes' => [
@@ -102,6 +104,7 @@ class FrontifyAssetFieldWidget extends LinkWidget {
             'context' => 'media_form',
             'api_url' => $config->get('frontify_api_url'),
             'debug_mode' => $config->get('debug_mode'),
+            'preview_image_width' => self::PREVIEW_IMAGE_WIDTH,
           ],
         ],
       ],


### PR DESCRIPTION
Preview image is currently the plain image url = original size.

As an MVP, add a width constraint to save bandwidth and improve editor experience.

This can still be extended with a field widget configuration form and/or we might also want to refactor the form to have 2 columns.