### PR TITLE
fix: prevent media library interaction without the finder

### DIFF
--- a/js/frontify_media_library.js
+++ b/js/frontify_media_library.js
@@ -24,7 +24,7 @@
         const $frontifyUriField = $mediaLibraryWrapper.querySelector('.js-form-item-uri');
         const $frontifyIdField = $mediaLibraryWrapper.querySelector('.js-form-item-id');
         const $frontifyMetadataField = $mediaLibraryWrapper.querySelector('.js-form-item-metadata');
-        const $frontifyImagePreivew = $mediaLibraryWrapper.querySelector('.frontify-image-preview');
+        const $frontifyImagePreview = $mediaLibraryWrapper.querySelector('.frontify-image-preview');
 
         // Look for an optional field to auto-select the entity browser widget.
         let $frontifyAutoSelect = null;
@@ -40,7 +40,7 @@
 
         // Hide the name field until it's filled.
         $frontifyNameField.style.display = 'none';
-        $frontifyImagePreivew.style.display = 'none';
+        $frontifyImagePreview.style.display = 'none';
 
         $mediaLibraryWrapper.classList.add('open');
 
@@ -85,6 +85,11 @@
             },
           });
 
+          // Make the media library visible once Frontify is ready.
+          if ($finder) {
+            $mediaLibraryWrapper.classList.remove('visually-hidden');
+          }
+
           // It's not possible to easily override the Media Library title with
           // the UI builder, also, Gutenberg has its own implementation
           // so change it here.
@@ -122,9 +127,9 @@
               const label = document.createElement('label');
               label.textContent = Drupal.t('Image Preview');
               label.classList.add('form-item__label');
-              $frontifyImagePreivew.replaceChildren(label, image);
+              $frontifyImagePreview.replaceChildren(label, image);
             }
-            $frontifyImagePreivew.style.display = 'block';
+            $frontifyImagePreview.style.display = 'block';
 
             $frontifyNameField.style.display = 'block';
             if (hideOpenButton) {
@@ -157,7 +162,7 @@
               button.target.style.display = 'block';
             }
             button.target.disabled = false;
-            $frontifyImagePreivew.style.display = 'none';
+            $frontifyImagePreview.style.display = 'none';
             $finderWrapper.style.display = 'none';
             $finderWrapper.replaceChildren();
             $mediaLibraryWrapper.classList.remove('open');
@@ -174,7 +179,7 @@
           }
           // Re-enable the submit button and the input field.
           $frontifyNameField.style.display = 'block';
-          $frontifyImagePreivew.style.display = 'none';
+          $frontifyImagePreview.style.display = 'none';
           if (hideOpenButton) {
             button.target.style.display = 'none';
           }

--- a/src/FrontifyFieldsUi.php
+++ b/src/FrontifyFieldsUi.php
@@ -58,10 +58,20 @@ final class FrontifyFieldsUi {
     }
 
     // Add a container to group the input elements for styling purposes.
+
+    $containerClasses = ['frontify-media-library-wrapper'];
+    if ($config->frontify_context === 'media_library') {
+      // Hide by default until Frontify finder is ready.
+      // This prevents a flash of content when opening the Media library
+      // and the user to interact with Drupal import
+      // before having the finder fully loaded.
+      $containerClasses[] = 'visually-hidden';
+    }
+
     $fields['container'] = [
       '#type' => 'container',
       '#attributes' => [
-        'class' => ['frontify-media-library-wrapper'],
+        'class' => $containerClasses,
       ],
     ];
 


### PR DESCRIPTION
- Prevent the user to interact with Drupal import before having the Frontify finder fully loaded
- Prevent a flash of content when opening the Media library