### PR TITLE
fix: get latest instance of a frontify image for the focal point

### DIFF
--- a/src/FrontifyDirective.php
+++ b/src/FrontifyDirective.php
@@ -146,7 +146,9 @@ final class FrontifyDirective {
     $mediaImages = $mediaStorage->loadByProperties([$frontifyField . '.uri' => $src]);
     $mediaImage = NULL;
     if (!empty($mediaImages)) {
-      $mediaImage = reset($mediaImages);
+      // Always get the latest instance of a media
+      // if deduplicate is not configured.
+      $mediaImage = end($mediaImages);
     }
 
     if (


### PR DESCRIPTION
If deduplicate is not configured and if we are using the Drupal snapshot of Frontify metadata, using `reset` will get the first instance of a Frontify image, so a stale focal point. Use `end` to get the most recent instance.

If more up-to-date metadata are needed, the client can still use the `FrontifyApi` class.